### PR TITLE
Added error handling for Nvidia GPU, fixed some pylint errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,9 @@ GPUtil
 pyadl
 psutil
 humanize
+cpuinfo
+wmi
+platform
+socket
+threading
+subprocess

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-psutil
-humanize
 dearpygui
 py-cpuinfo
 GPUtil
 pyadl
-wmi #windows only
+psutil
+humanize

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,7 @@
-dearpygui
-py-cpuinfo
-GPUtil
-pyadl
 psutil
 humanize
+dearpygui
 cpuinfo
-wmi
-platform
-socket
-threading
-subprocess
+GPUtil
+pyadl
+wmi #windows only

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 psutil
 humanize
 dearpygui
-cpuinfo
+py-cpuinfo
 GPUtil
 pyadl
 wmi #windows only

--- a/sysig.py
+++ b/sysig.py
@@ -5,7 +5,7 @@
 """
 
 # pylint: disable=line-too-long, import-error
-# pylint: disable=C0103
+# pylint: disable=C0103, W0718
 
 from datetime import datetime
 
@@ -139,6 +139,7 @@ with dpg.window(
         gpu_list = []
 
         def handle_nvidia_gpus():
+            """handle NVIDIA GPUs"""
             gpus = GPUtil.getGPUs()
             for gpu in gpus:
                 if gpu.id not in gpu_temp_texts:
@@ -155,6 +156,7 @@ with dpg.window(
                     dpg.set_value(gpu_temp_texts[gpu.id], f"Temperature: {gpu.temperature}°C")
 
         def handle_amd_gpus():
+            """handle AMD GPUs"""
             if not AMD_SUPPORTED:
                 return
 
@@ -186,7 +188,7 @@ with dpg.window(
                     dpg.add_text(f"Error fetching AMD GPU temperature: {e}", bullet=True, parent=gpu_temp_placeholder)
 
                 time.sleep(1)
-                
+
         # Get GPU Utilization
         def get_gpu_util():
             """Get GPU Utilization"""

--- a/sysig.py
+++ b/sysig.py
@@ -4,9 +4,6 @@
     Simple GUI tool to gather system information in your computer
 """
 
-# pylint: disable=line-too-long, import-error
-# pylint: disable=C0103, W0718
-
 from datetime import datetime
 
 import time

--- a/sysig.py
+++ b/sysig.py
@@ -179,15 +179,16 @@ with dpg.window(
 
         def update_gpu_temperatures():
             while True:
-                # NVIDIA GPU temperatures
+            # NVIDIA GPU temperatures
                 try:
                     gpus = GPUtil.getGPUs()
                     for gpu in gpus:
                         if gpu.id not in gpu_temp_texts:
-                            gpu_temp_text_id = dpg.add_text(f"Graphics Name: {gpu.name} Temperature: {gpu.temperature}°C", bullet=True, parent=gpu_temp_placeholder)
+                            dpg.add_text(f"Graphics Name: {gpu.name}", bullet=True, parent=gpu_temp_placeholder)
+                            gpu_temp_text_id = dpg.add_text(f"Temperature: {gpu.temperature}°C", bullet=True, parent=gpu_temp_placeholder)
                             gpu_temp_texts[gpu.id] = gpu_temp_text_id
                         else:
-                            dpg.set_value(gpu_temp_texts[gpu.id], f"Graphics Name: {gpu.name} Temperature: {gpu.temperature}°C")
+                            dpg.set_value(gpu_temp_texts[gpu.id], f"Temperature: {gpu.temperature}°C")
                 except (ImportError, Exception) as e:
                     dpg.add_text(f"Error fetching NVIDIA GPU temperature: {e}", bullet=True, parent=gpu_temp_placeholder)
 
@@ -200,10 +201,11 @@ with dpg.window(
                             temperature_data = device.getTemperature()
                             if temperature_data is not None:
                                 if device.adapterName not in amd_gpu_temp_texts:
-                                    amd_gpu_temp_text_id = dpg.add_text(f"AMD GPU {device.adapterName} Temperature: {temperature_data}°C", bullet=True, parent=gpu_temp_placeholder)
+                                    dpg.add_text(f"AMD GPU {device.adapterName}", bullet=True, parent=gpu_temp_placeholder)
+                                    amd_gpu_temp_text_id = dpg.add_text(f"Temperature: {temperature_data}°C", bullet=True, parent=gpu_temp_placeholder)
                                     amd_gpu_temp_texts[device.adapterName] = amd_gpu_temp_text_id
                                 else:
-                                    dpg.set_value(amd_gpu_temp_texts[device.adapterName], f"AMD GPU {device.adapterName} Temperature: {temperature_data}°C")
+                                    dpg.set_value(amd_gpu_temp_texts[device.adapterName], f"Temperature: {temperature_data}°C")
                     except Exception as e:
                         dpg.add_text(f"Error fetching AMD GPU temperature: {e}", bullet=True, parent=gpu_temp_placeholder)
 

--- a/sysig.py
+++ b/sysig.py
@@ -146,7 +146,11 @@ with dpg.window(
                         gpu_progress_bar = dpg.add_progress_bar(default_value=0.0, overlay="0.0%", width=200)
                         gpu_progress_bars[gpu.id] = gpu_progress_bar
 
-                    gpu_temp_text_id = dpg.add_text(f"Temperature: {gpu.temperature}°C", bullet=True, parent=gpu_temp_placeholder)
+                    gpu_temp_text_id = dpg.add_text(
+                        f"Temperature: {gpu.temperature}°C",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
                     gpu_temp_texts[gpu.id] = gpu_temp_text_id
 
                 else:
@@ -163,26 +167,49 @@ with dpg.window(
                 temperature_data = device.getCurrentTemperature()
                 if temperature_data is not None:
                     if device.adapterName not in amd_gpu_temp_texts:
-                        dpg.add_text(f"AMD GPU {device.adapterName}", bullet=True, parent=gpu_temp_placeholder)
-                        amd_gpu_temp_text_id = dpg.add_text(f"Temperature: {temperature_data}°C", bullet=True, parent=gpu_temp_placeholder)
-                        amd_gpu_temp_texts[device.adapterName] = amd_gpu_temp_text_id
-                    else:
-                        dpg.set_value(amd_gpu_temp_texts[device.adapterName], f"Temperature: {temperature_data}°C")
+                        dpg.add_text(
+                        f"AMD GPU {device.adapterName}",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
+                    amd_gpu_temp_text_id = dpg.add_text(
+                        f"Temperature: {temperature_data}°C",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
+                    amd_gpu_temp_texts[device.adapterName] = amd_gpu_temp_text_id
+                else:
+                    dpg.set_value(
+                        amd_gpu_temp_texts[device.adapterName],
+                        f"Temperature: {temperature_data}°C"
+                    )
 
         def update_gpu_temperature():
             """Get GPU Temperature and Util Updates"""
             while True:
                 try:
                     handle_nvidia_gpus()
-                except ImportError as ie:
-                    dpg.add_text(f"Error importing GPUtil: {ie}", bullet=True, parent=gpu_temp_placeholder)
-                except Exception as e:
-                    dpg.add_text(f"Error fetching NVIDIA GPU information: {e}", bullet=True, parent=gpu_temp_placeholder)
+                except ImportError as import_error:
+                    dpg.add_text(
+                        f"Error importing GPUtil: {import_error}",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
+                except Exception as general_exception:
+                    dpg.add_text(
+                        f"Error fetching NVIDIA GPU information: {general_exception}",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
 
                 try:
                     handle_amd_gpus()
-                except Exception as e:
-                    dpg.add_text(f"Error fetching AMD GPU temperature: {e}", bullet=True, parent=gpu_temp_placeholder)
+                except Exception as general_exception:
+                    dpg.add_text(
+                        f"Error fetching AMD GPU temperature: {general_exception}",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
 
                 time.sleep(1)
 
@@ -196,8 +223,8 @@ with dpg.window(
                         gpu_val = gpu.load * 100
                         dpg.set_value(gpu_progress_bars[gpu.id], 1.0 / 100.0 * gpu_val)
                         dpg.configure_item(gpu_progress_bars[gpu.id], overlay=f"{gpu_val:.2f}%")
-                except (ImportError, Exception) as e:
-                    print(f"An error occurred: {e}")
+                except (ImportError, Exception) as general_exception:
+                    print(f"An error occurred: {general_exception}")
                 time.sleep(1)
 
     with dpg.collapsing_header(label="Memory"):
@@ -253,7 +280,6 @@ with dpg.window(
                         dpg.add_text(f"{humanize.naturalsize(usage.used)}({usage.percent}%)")
                         dpg.add_text(f"{humanize.naturalsize(usage.free)}")
                         dpg.add_text(f"{humanize.naturalsize(usage.total)}")
-
 
     with dpg.collapsing_header(label="Network"):
         addr_list = psutil.net_if_addrs()

--- a/sysig.py
+++ b/sysig.py
@@ -85,7 +85,7 @@ def get_cpu_temperature():
             return temp['TC0D'][0].current
     return None
 
-def update_cpu_temperatures():
+def update_cpu_temperature():
     while True:
         cpu_temp = get_cpu_temperature()
         if isinstance(cpu_temp, (float, int)):
@@ -175,7 +175,7 @@ with dpg.window(
         gpu_temp_placeholder = dpg.add_group(horizontal=False)
         gpu_list = []
 
-        def update_gpu_temperatures():
+        def update_gpu_temperature():
             while True:
             # NVIDIA GPU temperatures
                 try:
@@ -316,8 +316,8 @@ with dpg.window(
         boot = bt.strftime("%m/%d/%Y %I:%M:%S %p")
         dpg.add_text(f"Last boot timestamp: {boot}", bullet=True)
         
-threading.Thread(target=update_gpu_temperatures, daemon=True).start()
-threading.Thread(target=update_cpu_temperatures, daemon=True).start()
+threading.Thread(target=update_gpu_temperature, daemon=True).start()
+threading.Thread(target=update_cpu_temperature, daemon=True).start()
 
 dpg.create_viewport(
     title="System Information Gatherer",

--- a/sysig.py
+++ b/sysig.py
@@ -7,9 +7,6 @@
 # pylint: disable=line-too-long
 # pylint: disable=C0103
 
-import dearpygui.dearpygui as dpg
-from cpuinfo import get_cpu_info
-
 from datetime import datetime
 
 import time
@@ -18,6 +15,8 @@ import winreg
 import socket
 import threading
 import subprocess
+import dearpygui.dearpygui as dpg
+from cpuinfo import get_cpu_info
 import GPUtil
 import psutil
 import humanize
@@ -143,7 +142,6 @@ with dpg.window(
                         dpg.configure_item(gpu_progress_bars[gpu.id], overlay=f"{gpu_val:.2f}%")
                 except (ImportError, Exception) as e:
                     print(f"An error occurred: {e}")
-                    pass
                 time.sleep(1)
 
         def update_gpu_temperature():
@@ -169,12 +167,9 @@ with dpg.window(
                 except ImportError as ie:
                     # Handle the ImportError
                     dpg.add_text(f"Error importing GPUtil: {ie}", bullet=True, parent=gpu_temp_placeholder)
-                except GPUtil.GPUtilException as ge:
-                    # Handle the GPUtilException
-                    dpg.add_text(f"Error fetching NVIDIA GPU information: {ge}", bullet=True, parent=gpu_temp_placeholder)
-                except Exception as e:
+                except Exception as e:  # Replacing GPUtil.GPUtilException with a generic Exception
                     # Handle other specific exceptions
-                    dpg.add_text(f"Unexpected error: {e}", bullet=True, parent=gpu_temp_placeholder)
+                    dpg.add_text(f"Error fetching NVIDIA GPU information: {e}", bullet=True, parent=gpu_temp_placeholder)
 
                 # AMD GPU temperatures
                 if AMD_SUPPORTED:

--- a/sysig.py
+++ b/sysig.py
@@ -140,10 +140,18 @@ with dpg.window(
             gpus = GPUtil.getGPUs()
             for gpu in gpus:
                 if gpu.id not in gpu_temp_texts:
-                    dpg.add_text(f"Graphics Name: {gpu.name}", bullet=True, parent=gpu_temp_placeholder)
+                    dpg.add_text(
+                        f"Graphics Name: {gpu.name}",
+                        bullet=True,
+                        parent=gpu_temp_placeholder
+                    )
                     with dpg.group(horizontal=True, parent=gpu_temp_placeholder):
                         dpg.add_text("GPU Utilization:", bullet=True)
-                        gpu_progress_bar = dpg.add_progress_bar(default_value=0.0, overlay="0.0%", width=200)
+                        gpu_progress_bar = dpg.add_progress_bar(
+                            default_value=0.0,
+                            overlay="0.0%",
+                            width=200
+                        )
                         gpu_progress_bars[gpu.id] = gpu_progress_bar
 
                     gpu_temp_text_id = dpg.add_text(
@@ -152,9 +160,11 @@ with dpg.window(
                         parent=gpu_temp_placeholder
                     )
                     gpu_temp_texts[gpu.id] = gpu_temp_text_id
-
                 else:
-                    dpg.set_value(gpu_temp_texts[gpu.id], f"Temperature: {gpu.temperature}°C")
+                    dpg.set_value(
+                        gpu_temp_texts[gpu.id],
+                        f"Temperature: {gpu.temperature}°C"
+                    )
 
         def handle_amd_gpus():
             """handle AMD GPUs"""

--- a/sysig.py
+++ b/sysig.py
@@ -4,7 +4,7 @@
     Simple GUI tool to gather system information in your computer
 """
 
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long, import-error
 # pylint: disable=C0103
 
 from datetime import datetime
@@ -29,8 +29,10 @@ try:
     AMD_SUPPORTED = True
 except ImportError:
     pass
-except Exception as e:
-    print(f"Unexpected error while checking for AMD support: {e}")
+except Exception as amd_error:
+    # Only print the AMD error if no NVIDIA GPUs are detected
+    if not GPUtil.getGPUs():
+        print(f"Unexpected error while checking for AMD support: {amd_error}")
 
 # Check for Windows and conditionally import winreg
 if platform.system() == 'Windows':

--- a/sysig.py
+++ b/sysig.py
@@ -11,11 +11,9 @@ import platform
 import socket
 import threading
 import subprocess
+import GPUtil
 import psutil
 import humanize
-import dearpygui.dearpygui as dpg
-from cpuinfo import get_cpu_info
-import GPUtil
 
 # Conditionally import wmi for Windows
 if platform.system() == 'Windows':

--- a/sysig.py
+++ b/sysig.py
@@ -11,7 +11,6 @@ from datetime import datetime
 
 import time
 import platform
-import winreg
 import socket
 import threading
 import subprocess
@@ -28,9 +27,16 @@ try:
     import pyadl
     _ = pyadl.ADLManager.getInstance().getDevices()
     AMD_SUPPORTED = True
-except (ImportError, Exception):
+except ImportError:
     pass
+except Exception as e:
+    print(f"Unexpected error while checking for AMD support: {e}")
 
+# Check for Windows and conditionally import winreg
+if platform.system() == 'Windows':
+    import winreg
+else:
+    winreg = None
 
 gci = get_cpu_info()
 WIN_WIDTH = 800

--- a/sysig.py
+++ b/sysig.py
@@ -218,7 +218,7 @@ with dpg.window(
                         amd_manager = pyadl.ADLManager.getInstance()
                         devices = amd_manager.getDevices()
                         for device in devices:
-                            temperature_data = device.getTemperature()
+                            temperature_data = device.getCurrentTemperature()
                             if temperature_data is not None:
                                 if device.adapterName not in amd_gpu_temp_texts:
                                     dpg.add_text(f"AMD GPU {device.adapterName}", bullet=True, parent=gpu_temp_placeholder)


### PR DESCRIPTION
I added a few error handling options for Nvidia GPU, and fixed some pylint errors. (trailing whitespaces, missing doc string)  I added # pylint: disable=line-too-long & # pylint: disable=C0103 so single letter variables and lines over 100 char will pass pylint.  Let me know if you want to include these changes.  I would like to get the pylint back to passing, as it was before my previous PR.